### PR TITLE
style: align dashboard layout with reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.env
+.env.*
+.vscode/

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import "../styles/globals.css";
+
+export const metadata: Metadata = {
+  title: "Lucky Trading Dashboard",
+  description: "Lucky Trading777 仪表盘布局原型",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="zh-CN">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import Dashboard from "../shared/components/Dashboard";
+
+export default function Page() {
+  return <Dashboard />;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "luckytrading777",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.66",
+    "@types/react-dom": "18.2.22",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/shared/components/Dashboard.tsx
+++ b/shared/components/Dashboard.tsx
@@ -1,0 +1,632 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+
+type Zone = {
+  name: string;
+  timeZone: string;
+};
+
+type ClockSnapshot = {
+  clocks: { name: string; time: string }[];
+  dateText: string;
+};
+
+function useClockData(): ClockSnapshot {
+  const zones: Zone[] = useMemo(
+    () => [
+      { name: "纽约", timeZone: "America/New_York" },
+      { name: "加州", timeZone: "America/Los_Angeles" },
+      { name: "上海", timeZone: "Asia/Shanghai" },
+    ],
+    []
+  );
+
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setNow(new Date());
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const timeFormatter = useMemo(
+    () =>
+      Object.fromEntries(
+        zones.map((zone) => [
+          zone.timeZone,
+          new Intl.DateTimeFormat("zh-CN", {
+            hour: "2-digit",
+            minute: "2-digit",
+            second: "2-digit",
+            hour12: false,
+            timeZone: zone.timeZone,
+          }),
+        ])
+      ),
+    [zones]
+  ) as Record<string, Intl.DateTimeFormat>;
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("zh-CN", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        timeZone: "Asia/Shanghai",
+      }),
+    []
+  );
+
+  const weekdayFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("zh-CN", {
+        weekday: "short",
+        timeZone: "Asia/Shanghai",
+      }),
+    []
+  );
+
+  const clocks = zones.map((zone) => ({
+    name: zone.name,
+    time: timeFormatter[zone.timeZone].format(now),
+  }));
+
+  const dateText = `${dateFormatter.format(now)} ${weekdayFormatter
+    .format(now)
+    .replace("星期", "周")}`;
+
+  return { clocks, dateText };
+}
+
+function HeaderBar({ clocks, dateText }: ClockSnapshot) {
+  return (
+    <div className="headerBar">
+      <div className="headerInner">
+        <div className="headerClocks">
+          {clocks.map((clock) => (
+            <span key={clock.name}>
+              {clock.name}: {clock.time}
+            </span>
+          ))}
+        </div>
+        <div className="headerActions">
+          <button className="btn">导入</button>
+          <button className="btn">导出</button>
+          <button className="btn">导入报价</button>
+          <div className="headerDate">{dateText}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type Tone = "up" | "down" | "";
+
+function KPI({ title, value, tone }: { title: string; value: string; tone?: Tone }) {
+  return (
+    <div className="card">
+      <div className="kpiTitle">{title}</div>
+      <div className={`kpiValue ${tone === "up" ? "up" : tone === "down" ? "down" : ""}`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function StatsGrid() {
+  const items: { title: string; value: string; tone?: Tone }[] = [
+    { title: "持仓成本", value: "$438,156.90" },
+    { title: "持仓市值", value: "$461,767.50" },
+    { title: "持仓浮盈", value: "$23,610.60", tone: "up" },
+    { title: "今天持仓盈亏", value: "$0.00" },
+    { title: "今日总盈亏变化", value: "$23,610.60", tone: "up" },
+    { title: "今日交易盈亏", value: "交割: $0.00 / FIFO: $0.00" },
+    { title: "今日交易次数", value: "B/S 0/0  P/O 0/0 [0]" },
+    { title: "累计交易次数", value: "B/S 0/0  P/O 0/0 [0]" },
+    { title: "所有历史平仓盈利", value: "$0.00" },
+    { title: "胜率", value: "W/0 L/0 0.00%" },
+    { title: "WTD", value: "$23,610.60", tone: "up" },
+    { title: "MTD", value: "$23,610.60", tone: "up" },
+    { title: "YTD", value: "$23,610.60", tone: "up" },
+    { title: "最大回撤", value: "-5.3%", tone: "down" },
+    { title: "仓位使用率", value: "64.2%" },
+    { title: "现金余额", value: "$158,202.18" },
+  ];
+  return (
+    <div className="grid stats section">
+      {items.map((item) => (
+        <KPI key={item.title} title={item.title} value={item.value} tone={item.tone} />
+      ))}
+    </div>
+  );
+}
+
+type TabKey = "当前持仓" | "交易分析";
+
+function Tabs({ active, onChange }: { active: TabKey; onChange: (tab: TabKey) => void }) {
+  return (
+    <div className="tabs section">
+      {(["当前持仓", "交易分析"] as TabKey[]).map((tab) => (
+        <div
+          key={tab}
+          className={`tab ${active === tab ? "active" : ""}`}
+          onClick={() => onChange(tab)}
+        >
+          {tab}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+type PositionRow = {
+  code: string;
+  cn: string;
+  price: number;
+  qty: number;
+  avg: number;
+  last: number;
+  pnl: number;
+  rate: number;
+  win: number;
+  times: number;
+};
+
+function PositionsTable({ rows }: { rows: PositionRow[] }) {
+  const totals = rows.reduce(
+    (acc, row) => {
+      acc.qty += row.qty;
+      acc.pnl += row.pnl;
+      acc.win += row.win;
+      acc.times += row.times;
+      return acc;
+    },
+    { qty: 0, pnl: 0, win: 0, times: 0 }
+  );
+
+  return (
+    <div className="panel section">
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 12,
+        }}
+      >
+        <div style={{ display: "flex", gap: 12, fontWeight: 700 }}>
+          <span>当前持仓</span>
+          <span style={{ color: "var(--muted)", fontWeight: 500 }}>交易分析</span>
+        </div>
+        <div style={{ color: "var(--muted)", fontSize: 12 }}>最近更新：05:35:12</div>
+      </div>
+      <div className="tableWrap">
+        <table>
+          <thead>
+            <tr>
+              <th>LOGO</th>
+              <th>代码</th>
+              <th>中文</th>
+              <th>实时报价</th>
+              <th>持仓</th>
+              <th>均价</th>
+              <th>现价</th>
+              <th>持仓浮盈</th>
+              <th>收益比例</th>
+              <th>胜率</th>
+              <th>历史交易次数</th>
+              <th>详情</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.code}>
+                <td>
+                  <div
+                    style={{
+                      width: 28,
+                      height: 28,
+                      borderRadius: "50%",
+                      background: "rgba(255,255,255,0.06)",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      fontSize: 12,
+                      fontWeight: 700,
+                    }}
+                  >
+                    {row.code.slice(0, 2)}
+                  </div>
+                </td>
+                <td>{row.code}</td>
+                <td style={{ textAlign: "left" }}>{row.cn}</td>
+                <td>{row.price.toFixed(2)}</td>
+                <td>{row.qty.toLocaleString()}</td>
+                <td>{row.avg.toFixed(2)}</td>
+                <td>{row.last.toFixed(2)}</td>
+                <td className={row.pnl >= 0 ? "up" : "down"}>
+                  {row.pnl >= 0 ? `+${row.pnl.toFixed(2)}` : row.pnl.toFixed(2)}
+                </td>
+                <td className={row.rate >= 0 ? "up" : "down"}>
+                  {row.rate >= 0 ? `+${row.rate.toFixed(2)}%` : `${row.rate.toFixed(2)}%`}
+                </td>
+                <td className={row.win >= 0 ? "up" : "down"}>
+                  {row.win >= 0 ? `+${row.win.toFixed(2)}` : row.win.toFixed(2)}
+                </td>
+                <td>{row.times}</td>
+                <td>
+                  <a href="#">详情</a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colSpan={4} style={{ textAlign: "left" }}>
+                合计
+              </td>
+              <td>{totals.qty.toLocaleString()}</td>
+              <td colSpan={2} style={{ textAlign: "center", color: "var(--muted)" }}>
+                --
+              </td>
+              <td className={totals.pnl >= 0 ? "up" : "down"}>
+                {totals.pnl >= 0 ? `+${totals.pnl.toFixed(2)}` : totals.pnl.toFixed(2)}
+              </td>
+              <td style={{ color: "var(--muted)" }}>--</td>
+              <td className={totals.win >= 0 ? "up" : "down"}>
+                {totals.win >= 0 ? `+${totals.win.toFixed(2)}` : totals.win.toFixed(2)}
+              </td>
+              <td>{totals.times}</td>
+              <td></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function AnalysisPlaceholder() {
+  return (
+    <div className="panel section" style={{ minHeight: 200 }}>
+      <div style={{ fontWeight: 700, marginBottom: 8 }}>交易分析</div>
+      <p style={{ color: "var(--muted)", margin: 0 }}>
+        即将上线：盈亏拆解、策略胜率、持仓周期等图表分析。
+      </p>
+    </div>
+  );
+}
+
+type Trade = {
+  date: string;
+  time: string;
+  week: string;
+  code: string;
+  cn: string;
+  side: "BUY" | "SELL";
+  price: number;
+  qty: number;
+  amount: number;
+};
+
+function TradesTable({ rows }: { rows: Trade[] }) {
+  const totals = rows.reduce(
+    (acc, row) => {
+      acc.qty += row.qty;
+      acc.amount += row.amount;
+      return acc;
+    },
+    { qty: 0, amount: 0 }
+  );
+
+  return (
+    <div className="panel section">
+      <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 12 }}>
+        <div style={{ fontWeight: 700 }}>交易记录</div>
+        <a href="#" style={{ color: "var(--muted)" }}>
+          查看全部
+        </a>
+      </div>
+      <div className="tableWrap">
+        <table>
+          <thead>
+            <tr>
+              <th>时间</th>
+              <th>星期</th>
+              <th>代码</th>
+              <th>中文</th>
+              <th>方向</th>
+              <th>单价</th>
+              <th>数量</th>
+              <th>订单金额</th>
+              <th>详情</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, index) => (
+              <tr key={`${row.code}-${index}`}>
+                <td style={{ textAlign: "left" }}>
+                  {row.date} {row.time}
+                </td>
+                <td>{row.week}</td>
+                <td>{row.code}</td>
+                <td style={{ textAlign: "left" }}>{row.cn}</td>
+                <td className={row.side === "BUY" ? "up" : "down"}>{row.side}</td>
+                <td>{row.price.toFixed(2)}</td>
+                <td>{row.qty}</td>
+                <td>
+                  {row.amount.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}
+                </td>
+                <td>
+                  <a href="#">详情</a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colSpan={6} style={{ textAlign: "left" }}>
+                合计
+              </td>
+              <td>{totals.qty}</td>
+              <td>{totals.amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function ChipRow({
+  chips,
+  active,
+  onSelect,
+}: {
+  chips: string[];
+  active: string;
+  onSelect: (chip: string) => void;
+}) {
+  return (
+    <div className="panel section">
+      <div style={{ fontWeight: 700, marginBottom: 12 }}>个股情况</div>
+      <div className="badgeRow">
+        {chips.map((chip) => (
+          <div
+            key={chip}
+            className={`badge ${active === chip ? "active" : ""}`}
+            onClick={() => onSelect(chip)}
+          >
+            {chip}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const POSITION_ROWS: PositionRow[] = [
+  {
+    code: "TSDD",
+    cn: "所罗门实验科技",
+    price: 10.22,
+    qty: 10000,
+    avg: 11.04,
+    last: 11.04,
+    pnl: -3200,
+    rate: -7.43,
+    win: -3200,
+    times: 12,
+  },
+  {
+    code: "BA",
+    cn: "波音",
+    price: 215.1,
+    qty: 350,
+    avg: 216.27,
+    last: 216.27,
+    pnl: -409.5,
+    rate: -0.54,
+    win: -409.5,
+    times: 8,
+  },
+  {
+    code: "GOOGL",
+    cn: "谷歌A",
+    price: 247.14,
+    qty: 400,
+    avg: 170.73,
+    last: 170.73,
+    pnl: 30564,
+    rate: 44.75,
+    win: 30564,
+    times: 18,
+  },
+  {
+    code: "AMD",
+    cn: "超威半导体",
+    price: 160.88,
+    qty: 400,
+    avg: 151.72,
+    last: 151.72,
+    pnl: 3480.8,
+    rate: 6.04,
+    win: 3480.8,
+    times: 5,
+  },
+  {
+    code: "PYPL",
+    cn: "贝宝",
+    price: 68.54,
+    qty: 5500,
+    avg: 68.54,
+    last: 68.54,
+    pnl: 0,
+    rate: 0,
+    win: 0,
+    times: 21,
+  },
+  {
+    code: "UAL",
+    cn: "联合航空",
+    price: 101.39,
+    qty: 300,
+    avg: 101.03,
+    last: 103.7,
+    pnl: -693,
+    rate: -2.37,
+    win: -693,
+    times: 9,
+  },
+  {
+    code: "DIS",
+    cn: "迪士尼",
+    price: 113.43,
+    qty: 250,
+    avg: 116.83,
+    last: 116.83,
+    pnl: -850,
+    rate: -2.91,
+    win: -850,
+    times: 14,
+  },
+  {
+    code: "NVDL",
+    cn: "所罗门类多空热试",
+    price: 84.41,
+    qty: 340,
+    avg: 84.12,
+    last: 84.12,
+    pnl: 95.7,
+    rate: 0.34,
+    win: 95.7,
+    times: 3,
+  },
+];
+
+const TRADE_ROWS: Trade[] = [
+  {
+    date: "2025-05-23",
+    time: "05:22:24",
+    week: "Fri",
+    code: "NVDL",
+    cn: "所罗门类多空热试",
+    side: "BUY",
+    price: 84.12,
+    qty: 330,
+    amount: 27759.6,
+  },
+  {
+    date: "2025-05-23",
+    time: "05:21:59",
+    week: "Fri",
+    code: "DIS",
+    cn: "迪士尼",
+    side: "BUY",
+    price: 116.83,
+    qty: 250,
+    amount: 29207.5,
+  },
+  {
+    date: "2025-05-23",
+    time: "05:21:20",
+    week: "Fri",
+    code: "UAL",
+    cn: "联合航空",
+    side: "BUY",
+    price: 103.7,
+    qty: 300,
+    amount: 31110,
+  },
+  {
+    date: "2025-05-23",
+    time: "05:21:20",
+    week: "Fri",
+    code: "PYPL",
+    cn: "贝宝",
+    side: "BUY",
+    price: 68.54,
+    qty: 5555,
+    amount: 38039.7,
+  },
+  {
+    date: "2025-05-20",
+    time: "21:10:20",
+    week: "Tue",
+    code: "AMD",
+    cn: "超威半导体",
+    side: "SELL",
+    price: 152.5,
+    qty: 200,
+    amount: 30500,
+  },
+  {
+    date: "2025-05-18",
+    time: "19:04:12",
+    week: "Sun",
+    code: "BA",
+    cn: "波音",
+    side: "SELL",
+    price: 218.4,
+    qty: 150,
+    amount: 32760,
+  },
+  {
+    date: "2025-05-18",
+    time: "18:32:02",
+    week: "Sun",
+    code: "GOOGL",
+    cn: "谷歌A",
+    side: "SELL",
+    price: 244.5,
+    qty: 180,
+    amount: 44010,
+  },
+  {
+    date: "2025-05-16",
+    time: "15:18:44",
+    week: "Fri",
+    code: "TSDD",
+    cn: "所罗门实验科技",
+    side: "SELL",
+    price: 11.04,
+    qty: 2600,
+    amount: 28704,
+  },
+];
+
+export default function Dashboard() {
+  const [activeTab, setActiveTab] = useState<TabKey>("当前持仓");
+  const [activeChip, setActiveChip] = useState<string>(POSITION_ROWS[0]?.code ?? "");
+  const clockSnapshot = useClockData();
+
+  return (
+    <>
+      <HeaderBar {...clockSnapshot} />
+      <div className="container">
+        <StatsGrid />
+        <Tabs active={activeTab} onChange={setActiveTab} />
+        {activeTab === "当前持仓" ? (
+          <PositionsTable rows={POSITION_ROWS} />
+        ) : (
+          <AnalysisPlaceholder />
+        )}
+        <ChipRow
+          chips={POSITION_ROWS.map((row) => row.code)}
+          active={activeChip}
+          onSelect={setActiveChip}
+        />
+        <TradesTable rows={TRADE_ROWS} />
+      </div>
+      <div className="fab" onClick={() => alert(`为 ${activeChip || "新"} 标的添加交易（占位）`)}>
+        +
+      </div>
+    </>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,122 @@
+:root{
+  /* 深色基调（贴近图2） */
+  --bg: #0b1815;            /* 页面背景更深 */
+  --surface: #0f1f1a;       /* 面板底色 */
+  --surface-2:#10241e;      /* 次级面板/hover */
+  --card:#112820;           /* KPI卡片/表头底色 */
+  --border:#1b3b32;         /* 柔和边框 */
+  --text:#e7f2ee;           /* 正文文字 */
+  --muted:#9eb6af;          /* 次要文字 */
+  --up:#23d27a;             /* 上涨绿（更亮） */
+  --down:#ff5a5a;           /* 下跌红 */
+  --chip:#133027;           /* 胶囊标签底色 */
+  --chip-active:#1b4a3c;    /* 激活标签 */
+  --shadow: 0 8px 18px rgba(0,0,0,.35);
+}
+
+*{box-sizing:border-box;}
+html,body,#__next{height:100%;}
+body{
+  margin:0;
+  background:var(--bg);
+  color:var(--text);
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
+}
+a{color:var(--up);text-decoration:none;}
+a:hover{text-decoration:underline;}
+
+.container{max-width:1280px;margin:0 auto;padding:88px 18px 24px;} /* 预留顶部栏高度 */
+.section{margin-top:14px;}
+
+.headerBar{
+  position:sticky; top:0; z-index:30;
+  background: linear-gradient(180deg, #0b1815, rgba(11,24,21,.92));
+  backdrop-filter: blur(6px);
+  border-bottom:1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+.headerInner{
+  max-width:1280px; margin:0 auto; padding:10px 18px;
+  display:flex; align-items:center; justify-content:space-between; gap:12px;
+}
+.headerClocks{display:flex; gap:12px; font-size:12px; color:var(--muted); flex-wrap:wrap;}
+.headerDate{font-weight:700; font-size:13px;}
+.headerActions{display:flex; gap:8px; align-items:center; color:var(--muted);}
+.btn{
+  background:var(--chip); border:1px solid var(--border); color:var(--text);
+  padding:6px 12px; border-radius:8px; font-size:12px; cursor:pointer;
+  transition:background .2s ease;
+}
+.btn:hover{background:var(--chip-active);} 
+
+.grid{display:grid; gap:12px;}
+.grid.stats{grid-template-columns: repeat(4, minmax(0, 1fr));}
+@media (max-width: 1200px){ .grid.stats{grid-template-columns: repeat(2, minmax(0,1fr));} }
+
+.panel{
+  background: linear-gradient(180deg, var(--surface), var(--surface-2));
+  border:1px solid var(--border);
+  border-radius:14px;
+  padding:16px;
+  box-shadow: var(--shadow);
+}
+
+.card{
+  background: linear-gradient(180deg, var(--card), var(--surface));
+  border:1px solid var(--border);
+  border-radius:14px;
+  padding:16px;
+  box-shadow: var(--shadow);
+  min-height:96px;
+  display:flex; flex-direction:column; justify-content:center;
+}
+.kpiTitle{font-size:12px;color:var(--muted);letter-spacing:.2px;}
+.kpiValue{font-size:22px;font-weight:800;margin-top:6px;}
+.up{color:var(--up);} .down{color:var(--down);} 
+
+.tabs{display:flex; gap:8px; margin:16px 0 8px;}
+.tab{
+  padding:10px 18px; border-radius:999px; background:var(--chip); border:1px solid var(--border);
+  color:var(--text); cursor:pointer; user-select:none; transition:background .2s ease, transform .2s ease;
+}
+.tab:hover{background:var(--chip-active); transform:translateY(-1px);}
+.tab.active{background:var(--chip-active); box-shadow: var(--shadow);} 
+
+.badgeRow{display:flex; flex-wrap:wrap; gap:8px;}
+.badge{
+  background:var(--chip); border:1px solid var(--border);
+  border-radius:999px; padding:8px 14px; cursor:pointer; transition:background .2s ease, transform .2s ease;
+}
+.badge:hover{background:var(--chip-active); transform:translateY(-1px);} 
+.badge.active{background:var(--chip-active); box-shadow: var(--shadow);} 
+
+.tableWrap{overflow:auto; max-height:420px; border-radius:10px;}
+table{width:100%; border-collapse:separate; border-spacing:0; font-size:13px; min-width:960px;}
+thead th{
+  background:var(--card);
+  position:sticky; top:0; z-index:1;
+  text-align:right; color:var(--muted); font-weight:600;
+  border-bottom:1px solid var(--border);
+  padding:12px 12px;
+}
+thead th:first-child, tbody td:first-child{ text-align:left; }
+tbody td{
+  padding:12px 12px; border-bottom:1px solid var(--border);
+  text-align:right; white-space:nowrap;
+}
+tbody tr:nth-child(odd){ background: rgba(255,255,255,0.02);} 
+tbody tr:hover{background:rgba(255,255,255,0.04);} 
+tfoot td{
+  padding:14px 12px; background:var(--surface); border-top:1px solid var(--border); font-weight:700;
+}
+
+.fab{
+  position: fixed; right: 24px; bottom: 24px; width: 56px; height: 56px; border-radius: 50%;
+  background: var(--up); color: #062; display:flex; align-items:center; justify-content:center;
+  font-size: 28px; font-weight: 800; cursor: pointer; box-shadow: var(--shadow);
+}
+
+@media (max-width: 1024px){
+  .container{padding:88px 16px 24px;}
+  .headerInner{padding:10px 16px;}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "version": 2,
+  "framework": "nextjs",
+  "buildCommand": "next build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## Summary
- restyle the global palette, spacing, and surface treatments to match the darker reference dashboard
- introduce a sticky header with live clocks, action buttons, and refreshed KPI/tabs/chip styling
- refine positions and trades tables with consistent spacing, zebra striping, and summary rows

## Testing
- ⚠️ `npm install` *(fails: registry.npmjs.org returns 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d45e84eb3c832e8958c6ed152e072a